### PR TITLE
Fixed an XSS vulnerability

### DIFF
--- a/resources/core/adminserv.php
+++ b/resources/core/adminserv.php
@@ -63,6 +63,9 @@ class AdminServ {
 		if($text === null){
 			$text = '['.$client->getErrorCode().'] '.Utils::t( $client->getErrorMessage() );
 		}
+		else {
+			$text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+		}
 		
 		AdminServLogs::add('error', $text);
 		unset($_SESSION['info']);


### PR DESCRIPTION
HTML code could be displayed by passing it as an `error` GET parameter. This can lead to Javascript execution, which in turn can lead to user impersonation.